### PR TITLE
Prevent MQTT clients from publishing to command topics

### DIFF
--- a/src/ratgdo-platform.ts
+++ b/src/ratgdo-platform.ts
@@ -129,6 +129,16 @@ export class RatgdoPlatform implements DynamicPlatformPlugin {
   // Configure and start our MQTT broker.
   private configureBroker(): void {
 
+    this.broker.authorizePublish = (_client, packet, callback): void => {
+      const commandRegex = new RegExp("^([^/]+)/command/.+$", "gi");
+
+      if (commandRegex.test(packet.topic)) {
+        return callback(new Error("Clients are not allowed to publish command topics"));
+      }
+
+      return callback(null);
+    };
+
     // Capture any publish events to our MQTT broker for processing.
     this.broker.on("publish", (packet): void => {
 


### PR DESCRIPTION
Any client connected to the builtin MQTT broker can currently send commands to connected ratgdo devices (e.g. open/close the door, etc.). This PR deauthorizes such commands from being sent.